### PR TITLE
Fix a typo in generating URL for us-based regions

### DIFF
--- a/src/Url.ts
+++ b/src/Url.ts
@@ -7,7 +7,7 @@ const buildUrl = ({bucketName, region}: IConfig): string => {
     case "cn":
       return `https://${bucketName}.s3.${region}.amazonaws.com.${countryCode}`;
     default:
-      return `https://${bucketName}.s3-${region}.amazonaws.com`;
+      return `https://${bucketName}.s3.${region}.amazonaws.com`;
   }
 }
 


### PR DESCRIPTION
First of all, thank you for creating this package! I was using it today and I was getting errors until I realized that  there is a typo in how S3 URL is being generated for non-Chinese based regions. With this fix, the package works w/o custom URL on non-Chinese regions.